### PR TITLE
Verification email link is not shown with prefix or suffix

### DIFF
--- a/lib/at_resend_verification_email_link.html
+++ b/lib/at_resend_verification_email_link.html
@@ -1,7 +1,9 @@
 <template name="atResendVerificationEmailLink">
   <div class="at-resend-verification-email-link at-wrap">
-    <div class="padding">
+    <p>
+      {{preText}}
       <a href="{{resendVerificationEmailLink}}" id="at-resend-verification-email" class="at-link at-resend-verification-email positive {{disabled}}">{{linkText}}</a>
-    </div>
+      {{suffText}}
+    </p>
   </div>
 </template>

--- a/lib/at_resend_verification_email_link.html
+++ b/lib/at_resend_verification_email_link.html
@@ -1,5 +1,5 @@
 <template name="atResendVerificationEmailLink">
-  <div class="at-resend-verification-email-link at-wrap">
+  <div class="at-resend-verification-email-link at-wrap text-center">
     <p>
       {{preText}}
       <a href="{{resendVerificationEmailLink}}" id="at-resend-verification-email" class="at-link at-resend-verification-email positive {{disabled}}">{{linkText}}</a>


### PR DESCRIPTION
Formatting verification email link just like sign-up link. Earlier this template is not showing prefix and suffix even though helper functions are defined in accounts template
